### PR TITLE
fix default for lock file cleanup

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -14,4 +14,4 @@ $conf['mediaatticage']      = 60*60*24*30*1;
 $conf['mediaatticnoexonly'] = 1;
 $conf['metaage']            = 60*60*24*30*3;
 $conf['mediametaage']       = 60*60*24*30*2;
-$conf['lockage']            = 60*60*30;
+$conf['lockage']            = 60*30;


### PR DESCRIPTION
I believe the default age for lock files is wrong: in https://www.dokuwiki.org/plugin:cleanup it states that it's 30 minutes. Currently the code states 30 hours.